### PR TITLE
Use PSR12 Instead of PSR2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_install:
   - docker exec -t $(docker ps -qf "name=app") bash -c "composer install -n"
 
 script:
-  - docker exec -t $(docker ps -qf "name=app") bash -c "php -d swoole.enable_library=off ./vendor/bin/phpunit"
+  - docker exec -t $(docker ps -qf "name=app") bash -c "./vendor/bin/phpunit"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Just new pull request (and we need unit tests for new features)
 #### Code requirements
 
 + PHP 7.1+
-+ PSR1 and PSR2
++ [PSR1](https://www.php-fig.org/psr/psr-1/) and [PSR12](https://www.php-fig.org/psr/psr-12/)
 + Strict type
 
 ## Develop
@@ -46,6 +46,26 @@ docker exec -t $(docker ps -qf "name=app") bash -c "./vendor/bin/phpunit"
 
 ```php
 define('SWOOLE_USE_SHORTNAME', true); // or false (it depends on you)
+```
+
+## Coding Style Checks and Fixes
+
+To update Composer packages (optional):
+
+```bash
+docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole bash -c "composer update -n"
+```
+
+To check files against the PSR12 coding standard:
+
+```bash
+docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole bash -c "php -d swoole.enable_library=off ./vendor/bin/phpcs  --standard=PSR12 examples src"
+```
+
+To correct coding standard violations automatically:
+
+```bash
+docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole bash -c "php -d swoole.enable_library=off ./vendor/bin/phpcbf --standard=PSR12 examples src"
 ```
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "ext-swoole": ">=4.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~8.0"
+        "phpunit/phpunit": "~8.0",
+        "squizlabs/php_codesniffer": ">=3.0"
     },
     "autoload": {
         "files": [

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 if (!defined('SWOOLE_LIBRARY')) {

--- a/examples/mysqli/base.php
+++ b/examples/mysqli/base.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Swoole\Coroutine;
@@ -13,15 +14,14 @@ const N = 1024;
 Runtime::enableCoroutine();
 $s = microtime(true);
 Coroutine\run(function () {
-    $pool = new MysqliPool((new MysqliConfig)
+    $pool = new MysqliPool((new MysqliConfig())
         ->withHost(MYSQL_SERVER_HOST)
         ->withPort(MYSQL_SERVER_PORT)
         // ->withUnixSocket('/tmp/mysql.sock')
         ->withDbName(MYSQL_SERVER_DB)
         ->withCharset('utf8mb4')
         ->withUsername(MYSQL_SERVER_USER)
-        ->withPassword(MYSQL_SERVER_PWD)
-    );
+        ->withPassword(MYSQL_SERVER_PWD));
     for ($n = N; $n--;) {
         Coroutine::create(function () use ($pool) {
             $mysqli = $pool->get();

--- a/examples/mysqli/io_failure.php
+++ b/examples/mysqli/io_failure.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Swoole\Coroutine;
@@ -13,15 +14,14 @@ const C = 64;
 Runtime::enableCoroutine();
 $s = microtime(true);
 Coroutine\run(function () {
-    $pool = new MysqliPool((new MysqliConfig)
+    $pool = new MysqliPool((new MysqliConfig())
         ->withHost(MYSQL_SERVER_HOST)
         ->withPort(MYSQL_SERVER_PORT)
         // ->withUnixSocket('/tmp/mysql.sock')
         ->withDbName(MYSQL_SERVER_DB)
         ->withCharset('utf8mb4')
         ->withUsername(MYSQL_SERVER_USER)
-        ->withPassword(MYSQL_SERVER_PWD)
-    );
+        ->withPassword(MYSQL_SERVER_PWD));
     Coroutine::create(function () use ($pool) {
         $killer = $pool->get();
         while (true) {

--- a/examples/pdo/base.php
+++ b/examples/pdo/base.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Swoole\Coroutine;
@@ -13,15 +14,14 @@ const N = 1024;
 Runtime::enableCoroutine();
 $s = microtime(true);
 Coroutine\run(function () {
-    $pool = new PDOPool((new PDOConfig)
+    $pool = new PDOPool((new PDOConfig())
         ->withHost(MYSQL_SERVER_HOST)
         ->withPort(MYSQL_SERVER_PORT)
         // ->withUnixSocket('/tmp/mysql.sock')
         ->withDbName(MYSQL_SERVER_DB)
         ->withCharset('utf8mb4')
         ->withUsername(MYSQL_SERVER_USER)
-        ->withPassword(MYSQL_SERVER_PWD)
-    );
+        ->withPassword(MYSQL_SERVER_PWD));
     for ($n = N; $n--;) {
         Coroutine::create(function () use ($pool) {
             $pdo = $pool->get();

--- a/examples/pdo/io_failure.php
+++ b/examples/pdo/io_failure.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Swoole\ConnectionPool;

--- a/examples/redis/base.php
+++ b/examples/redis/base.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Swoole\Coroutine;
@@ -13,13 +14,12 @@ const N = 1024;
 Runtime::enableCoroutine();
 $s = microtime(true);
 Coroutine\run(function () {
-    $pool = new RedisPool((new RedisConfig)
+    $pool = new RedisPool((new RedisConfig())
         ->withHost(REDIS_SERVER_HOST)
         ->withPort(REDIS_SERVER_PORT)
         ->withAuth('')
         ->withDbIndex(0)
-        ->withTimeout(1)
-    );
+        ->withTimeout(1));
     for ($n = N; $n--;) {
         Coroutine::create(function () use ($pool) {
             $redis = $pool->get();

--- a/examples/string/mbstring.php
+++ b/examples/string/mbstring.php
@@ -1,4 +1,5 @@
 <?php
+
 require __DIR__ . '/../bootstrap.php';
 
 $str = _mbstring("我是中国人");

--- a/src/alias.php
+++ b/src/alias.php
@@ -1,4 +1,5 @@
 <?php
+
 if (SWOOLE_USE_SHORTNAME) {
     class_alias(Swoole\Coroutine\WaitGroup::class, Co\WaitGroup::class, true);
     class_alias(Swoole\Coroutine\Server::class, Co\Server::class, true);

--- a/src/alias_ns.php
+++ b/src/alias_ns.php
@@ -10,7 +10,6 @@ namespace Swoole\Coroutine {
     }
 
 }
-
 namespace Co {
 
     if (SWOOLE_USE_SHORTNAME) {

--- a/src/constants.php
+++ b/src/constants.php
@@ -1,2 +1,3 @@
 <?php
+
 define('SWOOLE_LIBRARY', true);

--- a/src/core/ConnectionPool.php
+++ b/src/core/ConnectionPool.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole;

--- a/src/core/Constant.php
+++ b/src/core/Constant.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole;

--- a/src/core/Coroutine/Server.php
+++ b/src/core/Coroutine/Server.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Coroutine;

--- a/src/core/Coroutine/Server/Connection.php
+++ b/src/core/Coroutine/Server/Connection.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Coroutine\Server;

--- a/src/core/Coroutine/WaitGroup.php
+++ b/src/core/Coroutine/WaitGroup.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Coroutine;

--- a/src/core/Curl/Exception.php
+++ b/src/core/Curl/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Curl;

--- a/src/core/Curl/Handler.php
+++ b/src/core/Curl/Handler.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpComposerExtensionStubsInspection, PhpDuplicateSwitchCaseBodyInspection, PhpInconsistentReturnPointsInspection */
 
 namespace Swoole\Curl;
@@ -597,7 +598,7 @@ final class Handler
         $this->info['total_time'] = microtime(true) - $timeBegin;
         $this->info['http_code'] = $client->statusCode;
         $this->info['content_type'] = $client->headers['content-type'] ?? '';
-        $this->info['size_download'] = $this->info['download_content_length'] = strlen($client->body);;
+        $this->info['size_download'] = $this->info['download_content_length'] = strlen($client->body);
         $this->info['speed_download'] = 1 / $this->info['total_time'] * $this->info['size_download'];
         if (isset($redirectBeginTime)) {
             $this->info['redirect_time'] = microtime(true) - $redirectBeginTime;

--- a/src/core/Database/MysqliConfig.php
+++ b/src/core/Database/MysqliConfig.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/MysqliException.php
+++ b/src/core/Database/MysqliException.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/MysqliPool.php
+++ b/src/core/Database/MysqliPool.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/MysqliProxy.php
+++ b/src/core/Database/MysqliProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/MysqliStatementProxy.php
+++ b/src/core/Database/MysqliStatementProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/PDOConfig.php
+++ b/src/core/Database/PDOConfig.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/PDOPool.php
+++ b/src/core/Database/PDOPool.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/PDOProxy.php
+++ b/src/core/Database/PDOProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/PDOStatementProxy.php
+++ b/src/core/Database/PDOStatementProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/RedisConfig.php
+++ b/src/core/Database/RedisConfig.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;

--- a/src/core/Database/RedisPool.php
+++ b/src/core/Database/RedisPool.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Database;
@@ -19,7 +20,7 @@ class RedisPool extends ConnectionPool
     {
         $this->config = $config;
         parent::__construct(function () {
-            $redis = new Redis;
+            $redis = new Redis();
             $redis->connect(
                 $this->config->getHost(),
                 $this->config->getPort(),

--- a/src/core/Http/Status.php
+++ b/src/core/Http/Status.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole\Http;

--- a/src/core/MultibyteStringObject.php
+++ b/src/core/MultibyteStringObject.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpComposerExtensionStubsInspection */
 
 namespace Swoole;

--- a/src/core/ObjectProxy.php
+++ b/src/core/ObjectProxy.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Swoole;

--- a/src/ext/curl.php
+++ b/src/ext/curl.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @noinspection PhpComposerExtensionStubsInspection */
 
 function swoole_curl_init(string $url = ''): Swoole\Curl\Handler

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,4 +1,5 @@
 <?php
+
 if (SWOOLE_USE_SHORTNAME) {
     /**
      * @param string $string

--- a/src/std/exec.php
+++ b/src/std/exec.php
@@ -1,4 +1,5 @@
 <?php
+
 function swoole_exec(string $command, &$output = null, &$returnVar = null)
 {
     $result = Swoole\Coroutine::exec($command);


### PR DESCRIPTION
As listed [here](https://www.php-fig.org/psr/), PSR2 is deprecated. This pull request is to

* use PSR12 instead of PSR2.
* fix coding style violations using _phpcbf_ automatically.
* simplify the _phpunit_ command used in Travis CI.