### PR TITLE
add Composer script cs-check to check coding standard violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ To update Composer packages (optional):
 docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole bash -c "composer update -n"
 ```
 
+To check coding standard violations:
+
+```bash
+docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole bash -c "composer cs-check"
+```
+
 To correct coding standard violations automatically:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         }
     },
     "scripts": {
+        "cs-check": "/usr/bin/env php -d swoole.enable_library=Off ./vendor/bin/php-cs-fixer fix --dry-run",
         "cs-fix": "/usr/bin/env php -d swoole.enable_library=Off ./vendor/bin/php-cs-fixer fix"
     }
 }


### PR DESCRIPTION
If coding standard violations can not be fixed automatically by PHP CS Fixer, this script can tell which PHP files to be fixed manually.