### PR TITLE
Disable Cloning of Database Proxy Objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,11 @@
             "Swoole\\": "src/core"
         }
     },
+    "autoload-dev": {
+        "classmap": [
+            "tests/DatabaseTestCase.php"
+        ]
+    },
     "scripts": {
         "cs-check": "/usr/bin/env php -d swoole.enable_library=Off ./vendor/bin/php-cs-fixer fix --dry-run",
         "cs-fix": "/usr/bin/env php -d swoole.enable_library=Off ./vendor/bin/php-cs-fixer fix"

--- a/src/core/Database/MysqliProxy.php
+++ b/src/core/Database/MysqliProxy.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Swoole\Database;
 
 use mysqli;
-use Swoole\ObjectProxy;
 
 class MysqliProxy extends ObjectProxy
 {

--- a/src/core/Database/MysqliStatementProxy.php
+++ b/src/core/Database/MysqliStatementProxy.php
@@ -13,7 +13,6 @@ namespace Swoole\Database;
 
 use mysqli;
 use mysqli_stmt;
-use Swoole\ObjectProxy;
 
 class MysqliStatementProxy extends ObjectProxy
 {

--- a/src/core/Database/ObjectProxy.php
+++ b/src/core/Database/ObjectProxy.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Database;
+
+use Error;
+
+class ObjectProxy extends \Swoole\ObjectProxy
+{
+    public function __clone()
+    {
+        throw new Error('Trying to clone an uncloneable database proxy object');
+    }
+}

--- a/src/core/Database/PDOProxy.php
+++ b/src/core/Database/PDOProxy.php
@@ -13,7 +13,6 @@ namespace Swoole\Database;
 
 use PDO;
 use PDOException;
-use Swoole\ObjectProxy;
 
 class PDOProxy extends ObjectProxy
 {

--- a/src/core/Database/PDOStatementProxy.php
+++ b/src/core/Database/PDOStatementProxy.php
@@ -14,7 +14,6 @@ namespace Swoole\Database;
 use PDO;
 use PDOException;
 use PDOStatement;
-use Swoole\ObjectProxy;
 
 class PDOStatementProxy extends ObjectProxy
 {

--- a/src/core/ObjectProxy.php
+++ b/src/core/ObjectProxy.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Swoole;
 
+use ErrorException;
 use TypeError;
 
 class ObjectProxy
@@ -24,6 +25,11 @@ class ObjectProxy
             throw new TypeError('Non-object given');
         }
         $this->__object = $object;
+    }
+
+    public function __clone()
+    {
+        throw new ErrorException('Trying to clone an uncloneable database proxy object in PHP/Swoole');
     }
 
     public function __getObject()

--- a/src/core/ObjectProxy.php
+++ b/src/core/ObjectProxy.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Swoole;
 
-use ErrorException;
 use TypeError;
 
 class ObjectProxy
@@ -25,11 +24,6 @@ class ObjectProxy
             throw new TypeError('Non-object given');
         }
         $this->__object = $object;
-    }
-
-    public function __clone()
-    {
-        throw new ErrorException('Trying to clone an uncloneable database proxy object in PHP/Swoole');
     }
 
     public function __getObject()

--- a/tests/DatabaseTestCase.php
+++ b/tests/DatabaseTestCase.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Swoole\Database\MysqliConfig;
+use Swoole\Database\MysqliPool;
+use Swoole\Database\PDOConfig;
+use Swoole\Database\PDOPool;
+use Swoole\Database\RedisConfig;
+use Swoole\Database\RedisPool;
+
+/**
+ * Class DatabaseTestCase
+ *
+ * @internal
+ * @coversNothing
+ */
+class DatabaseTestCase extends TestCase
+{
+    protected function getMysqliPool(): MysqliPool
+    {
+        $config = (new MysqliConfig())
+            ->withHost(MYSQL_SERVER_HOST)
+            ->withPort(MYSQL_SERVER_PORT)
+            ->withDbName(MYSQL_SERVER_DB)
+            ->withCharset('utf8mb4')
+            ->withUsername(MYSQL_SERVER_USER)
+            ->withPassword(MYSQL_SERVER_PWD);
+
+        return new MysqliPool($config);
+    }
+
+    protected function getPdoPool(): PDOPool
+    {
+        $config = (new PDOConfig())
+            ->withHost(MYSQL_SERVER_HOST)
+            ->withPort(MYSQL_SERVER_PORT)
+            ->withDbName(MYSQL_SERVER_DB)
+            ->withCharset('utf8mb4')
+            ->withUsername(MYSQL_SERVER_USER)
+            ->withPassword(MYSQL_SERVER_PWD);
+
+        return new PDOPool($config);
+    }
+
+    protected function getRedisPool(): RedisPool
+    {
+        $config = (new RedisConfig())->withHost(REDIS_SERVER_HOST)->withPort(REDIS_SERVER_PORT);
+
+        return new RedisPool($config);
+    }
+}

--- a/tests/unit/Database/PDOStatementProxyTest.php
+++ b/tests/unit/Database/PDOStatementProxyTest.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 namespace Swoole\Database;
 
 use PDO;
-use PHPUnit\Framework\TestCase;
 use Swoole\Coroutine;
+use Swoole\Tests\DatabaseTestCase;
 
 /**
  * Class PDOStatementProxyTest
@@ -21,7 +21,7 @@ use Swoole\Coroutine;
  * @internal
  * @coversNothing
  */
-class PDOStatementProxyTest extends TestCase
+class PDOStatementProxyTest extends DatabaseTestCase
 {
     /**
      * @covers \Swoole\Database\PDOStatementProxy::__call()
@@ -29,17 +29,8 @@ class PDOStatementProxyTest extends TestCase
     public function testRun()
     {
         Coroutine\run(function () {
-            $config = (new PDOConfig())
-                ->withHost(MYSQL_SERVER_HOST)
-                ->withPort(MYSQL_SERVER_PORT)
-                ->withDbName(MYSQL_SERVER_DB)
-                ->withCharset('utf8mb4')
-                ->withUsername(MYSQL_SERVER_USER)
-                ->withPassword(MYSQL_SERVER_PWD);
-
-            $db = (new PDOPool($config))->get();
             self::assertFalse(
-                $db->query("SHOW TABLES like 'NON_EXISTING_TABLE_NAME'")->fetch(PDO::FETCH_ASSOC),
+                $this->getPdoPool()->get()->query("SHOW TABLES like 'NON_EXISTING_TABLE_NAME'")->fetch(PDO::FETCH_ASSOC),
                 'FALSE is returned if no results found.'
             );
         });

--- a/tests/unit/ObjectProxyTest.php
+++ b/tests/unit/ObjectProxyTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Swoole;
 
-use ErrorException;
+use Error;
 use Swoole\Tests\DatabaseTestCase;
 
 /**
@@ -42,7 +42,7 @@ class ObjectProxyTest extends DatabaseTestCase
             foreach ($dbs as $db) {
                 try {
                     var_dump(clone $db);
-                } catch (ErrorException $e) {
+                } catch (Error $e) {
                     if ($e->getMessage() != 'Trying to clone an uncloneable database proxy object in PHP/Swoole') {
                         throw $e;
                     }

--- a/tests/unit/ObjectProxyTest.php
+++ b/tests/unit/ObjectProxyTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole;
+
+use ErrorException;
+use Swoole\Tests\DatabaseTestCase;
+
+/**
+ * Class ObjectProxyTest
+ *
+ * @internal
+ * @coversNothing
+ */
+class ObjectProxyTest extends DatabaseTestCase
+{
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->addToAssertionCount(2); // Add those in method $this->testClone().
+    }
+
+    /**
+     * @covers \Swoole\ObjectProxy::__clone()
+     */
+    public function testClone()
+    {
+        Coroutine\run(function () {
+            $dbs = [
+                $this->getPdoPool()->get(),
+                $this->getMysqliPool()->get(),
+            ];
+
+            foreach ($dbs as $db) {
+                try {
+                    clone $db;
+                } catch (ErrorException $e) {
+                    if ($e->getMessage() != 'Trying to clone an uncloneable database proxy object in PHP/Swoole') {
+                        throw $e;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/tests/unit/ObjectProxyTest.php
+++ b/tests/unit/ObjectProxyTest.php
@@ -29,7 +29,7 @@ class ObjectProxyTest extends DatabaseTestCase
     }
 
     /**
-     * @covers \Swoole\ObjectProxy::__clone()
+     * @covers \Swoole\Database\ObjectProxy::__clone()
      */
     public function testClone()
     {
@@ -41,7 +41,7 @@ class ObjectProxyTest extends DatabaseTestCase
 
             foreach ($dbs as $db) {
                 try {
-                    clone $db;
+                    var_dump(clone $db);
                 } catch (ErrorException $e) {
                     if ($e->getMessage() != 'Trying to clone an uncloneable database proxy object in PHP/Swoole') {
                         throw $e;

--- a/tests/unit/ObjectProxyTest.php
+++ b/tests/unit/ObjectProxyTest.php
@@ -43,7 +43,7 @@ class ObjectProxyTest extends DatabaseTestCase
                 try {
                     var_dump(clone $db);
                 } catch (Error $e) {
-                    if ($e->getMessage() != 'Trying to clone an uncloneable database proxy object in PHP/Swoole') {
+                    if ($e->getMessage() != 'Trying to clone an uncloneable database proxy object') {
                         throw $e;
                     }
                 }


### PR DESCRIPTION
In general database handle/connection objects shouldn't be cloneable. ([ref](https://bugs.php.net/bug.php?id=77849))