### PR TITLE
fix ConnectionPool@put when error happens

### DIFF
--- a/src/core/ConnectionPool.php
+++ b/src/core/ConnectionPool.php
@@ -70,6 +70,7 @@ class ConnectionPool
         } else {
             /* connection broken */
             $this->num -= 1;
+            $this->make();
         }
     }
 

--- a/tests/unit/Database/PDOPoolTest.php
+++ b/tests/unit/Database/PDOPoolTest.php
@@ -7,11 +7,11 @@
  * @license  https://github.com/swoole/library/blob/master/LICENSE
  */
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Swoole\Database;
 
-use PDO;
+use PDOException;
 use PHPUnit\Framework\TestCase;
 use Swoole\Coroutine;
 use Swoole\Runtime;
@@ -44,16 +44,14 @@ class PDOPoolTest extends TestCase
                 Coroutine::create(function () use ($pool, $n, &$actual) {
                     $pdo = $pool->get();
                     try {
-                        $statement = $pdo->prepare("SELECT :n as n");
+                        $statement = $pdo->prepare('SELECT :n as n');
                         $statement->execute([':n' => $n]);
-                        $row       = $statement->fetch(\PDO::FETCH_ASSOC);
+                        $row = $statement->fetch(\PDO::FETCH_ASSOC);
                         // simulate error happens
                         $statement = $pdo->prepare('KILL CONNECTION_ID()');
                         $statement->execute();
-                    } catch (\Throwable $th) {
-                        if ($th->getMessage() !== 'Connection was killed') {
-                            throw $th;
-                        }
+                    } catch (PDOException $th) {
+                        // do nothing
                     }
                     $pdo = null;
                     $pool->put(null);

--- a/tests/unit/Database/PDOPoolTest.php
+++ b/tests/unit/Database/PDOPoolTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare (strict_types = 1);
+
+namespace Swoole\Database;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Swoole\Coroutine;
+use Swoole\Runtime;
+
+/**
+ * Class PDOPoolTest
+ *
+ * @internal
+ * @coversNothing
+ */
+class PDOPoolTest extends TestCase
+{
+    public function testPutWhenErrorHappens()
+    {
+        $flags = Runtime::getHookFlags(SWOOLE_HOOK_ALL);
+        Runtime::enableCoroutine();
+        $expect = ['0', '1', '2', '3', '4'];
+        $actual = [];
+        Coroutine\run(function () use (&$actual) {
+            $config = (new PDOConfig())
+                ->withHost(MYSQL_SERVER_HOST)
+                ->withPort(MYSQL_SERVER_PORT)
+                ->withDbName(MYSQL_SERVER_DB)
+                ->withCharset('utf8mb4')
+                ->withUsername(MYSQL_SERVER_USER)
+                ->withPassword(MYSQL_SERVER_PWD);
+
+            $pool = new PDOPool($config, 2);
+            for ($n = 5; $n--;) {
+                Coroutine::create(function () use ($pool, $n, &$actual) {
+                    $pdo = $pool->get();
+                    try {
+                        $statement = $pdo->prepare("SELECT :n as n");
+                        $statement->execute([':n' => $n]);
+                        $row       = $statement->fetch(\PDO::FETCH_ASSOC);
+                        // simulate error happens
+                        $statement = $pdo->prepare('KILL CONNECTION_ID()');
+                        $statement->execute();
+                    } catch (\Throwable $th) {
+                        if ($th->getMessage() !== 'Connection was killed') {
+                            throw $th;
+                        }
+                    }
+                    $pdo = null;
+                    $pool->put(null);
+
+                    $actual[] = $row['n'];
+                });
+            }
+        });
+        sort($actual);
+        $this->assertEquals($expect, $actual);
+        Runtime::enableCoroutine($flags);
+    }
+}


### PR DESCRIPTION
when coroutine is enable:

```php
# ConnectionPool.php

    public function get()
    {
        if ($this->pool === null) {
            throw new RuntimeException('Pool has been closed');
        }
        if ($this->pool->isEmpty() && $this->num < $this->size) {
            $this->make();
        }
        return $this->pool->pop(); // <- coroutines which out of channel size will block here
    }
```

put method just minus the num, but not create a new connection

```php
# ConnectionPool.php
    public function put($connection): void
    {
        if ($this->pool === null) {
            return;
        }
        if ($connection !== null) {
            $this->pool->push($connection);
        } else {
            /* connection broken */
            $this->num -= 1;
        }
    }
```

so get method `$this->pool->pop()` will cause a dead lock

for this [issue](https://github.com/swoole/swoole-src/issues/2918) , coroutine will return directly without any exception
in the test case, result will contains 2 elements(as the number of the channel size) , which expects 5