### PR TITLE
Fix response header parsing when there is no space after the colon in the response header

### DIFF
--- a/src/core/FastCGI/HttpResponse.php
+++ b/src/core/FastCGI/HttpResponse.php
@@ -40,7 +40,9 @@ class HttpResponse extends Response
         [$headers, $body] = @explode("\r\n\r\n", $body, 2);
         $headers = explode("\r\n", $headers);
         foreach ($headers as $header) {
-            [$name, $value] = @explode(': ', $header, 2);
+            [$name, $value] = @explode(':', $header, 2);
+            $name = trim($name);
+            $value = trim($value);
             if (strcasecmp($name, 'Status') === 0) {
                 [$statusCode, $reasonPhrase] = @explode(' ', $value, 2);
             } elseif (strcasecmp($name, 'Set-Cookie') === 0) {


### PR DESCRIPTION
Fix response header parsing when there is no space after the colon in the response header

fix unresolved:

```php
<?php
header('Content-Type:application/json');
```
