### PR TITLE
remove error control operators

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,4 +3,9 @@
     <testsuite name="default">
         <directory suffix="Test.php">tests/unit</directory>
     </testsuite>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+    </php>
 </phpunit>

--- a/src/core/FastCGI/HttpResponse.php
+++ b/src/core/FastCGI/HttpResponse.php
@@ -39,7 +39,7 @@ class HttpResponse extends Response
         }
         $array = explode("\r\n\r\n", $body, 2); // An array that contains the HTTP headers and the body.
         if (count($array) != 2) {
-            $this->withStatusCode(502)->withReasonPhrase('Invalid FastCGI Response')->withError($body);
+            $this->withStatusCode(Status::BAD_GATEWAY)->withReasonPhrase('Invalid FastCGI Response')->withError($body);
             return;
         }
         $headers = explode("\r\n", $array[0]);

--- a/tests/unit/FastCGI/HttpResponseTest.php
+++ b/tests/unit/FastCGI/HttpResponseTest.php
@@ -195,7 +195,7 @@ EOT,
         $contentData = str_replace("\n", "\r\n", $contentData); // Our files uses LF but not CRLF.
         $response = new HttpResponse([new Stdout($contentData), new EndRequest()]);
         self::assertSame($expectedStatusCode, $response->getStatusCode(), 'test status code returned');
-        self::assertSame($expectedReasonPhrase, $response->getReasonPhrase(), 'test reason phrase (if included)');
+        self::assertSame($expectedReasonPhrase, $response->getReasonPhrase(), 'test reason phrase');
     }
 
     public function dataStatusFromFPM(): array
@@ -241,7 +241,7 @@ EOT,
                 $client = new Client('php-fpm', 9000);
                 $response = $client->execute((new HttpRequest())->withScriptFilename($filename));
                 self::assertSame($expectedStatusCode, $response->getStatusCode(), 'test status code returned');
-                self::assertSame($expectedReasonPhrase, $response->getReasonPhrase(), 'test reason phrase (if included)');
+                self::assertSame($expectedReasonPhrase, $response->getReasonPhrase(), 'test reason phrase');
             }
         );
     }

--- a/tests/unit/FastCGI/HttpResponseTest.php
+++ b/tests/unit/FastCGI/HttpResponseTest.php
@@ -46,6 +46,26 @@ Hello world!
 EOT,
                 'default headers from WordPress homepage',
             ],
+            [
+                [
+                    'X-Foo0' => 'Bar0',
+                    'X-Foo1' => 'Bar1',
+                    'X-Foo3' => 'Bar3',
+                    'X-Foo4' => 'Bar4',
+                    'X-Foo5' => 'Bar5',
+                ],
+                <<<'EOT'
+X-Foo0: Bar0
+X-Foo1:Bar1
+X-Foo2 Bar2
+X-Foo3:Bar3 
+ X-Foo4:Bar4
+ X-Foo5:  Bar5 
+
+Hello world!
+EOT,
+                'test variations of HTTP headers',
+            ],
         ];
     }
 
@@ -87,6 +107,19 @@ EOT,
                 DOCUMENT_ROOT . '/header1.php',
                 'Test headers returned from script "header1.php" (an HTTP header without space after the colon)',
             ],
+            [
+                [
+                    'X-Powered-By' => $this->poweredBy,
+                    'X-Foo0' => 'Bar0',
+                    'X-Foo1' => 'Bar1',
+                    'X-Foo3' => 'Bar3',
+                    'X-Foo4' => 'Bar4',
+                    'X-Foo5' => 'Bar5',
+                    'Content-type' => 'text/html; charset=UTF-8',
+                ],
+                DOCUMENT_ROOT . '/header2.php',
+                'Test variations of HTTP headers',
+            ],
         ];
     }
 
@@ -101,6 +134,114 @@ EOT,
                 $client = new Client('php-fpm', 9000);
                 $response = $client->execute((new HttpRequest())->withScriptFilename($filename));
                 self::assertSame($expectedHeaders, $response->getHeaders(), $message);
+            }
+        );
+    }
+
+    public function dataStatus(): array
+    {
+        return [
+            [
+                400,
+                'Bad Request',
+                <<<'EOT'
+Status: 400 Bad Request
+
+Hello world!
+EOT,
+                'test HTTP status overridden with reason phrase included',
+            ],
+            [
+                401,
+                'Unauthorized',
+                <<<'EOT'
+Status: 401
+
+Hello world!
+EOT,
+                'test HTTP status overridden without reason phrase included',
+            ],
+            [
+                402,
+                ' Payment Required',
+                <<<'EOT'
+Status:  402  Payment Required  
+
+Hello world!
+EOT,
+                'test HTTP status overridden with reason phrase and extra spaces included',
+            ],
+            [
+                403,
+                'Forbidden',
+                <<<'EOT'
+Status:  403  
+
+Hello world!
+EOT,
+                'test HTTP status overridden with extra spaces included, but no reason phrase',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataStatus
+     * @covers \Swoole\FastCGI\HttpResponse
+     * @param mixed $expectedStatusCode
+     * @param mixed $expectedReasonPhrase
+     */
+    public function testStatus($expectedStatusCode, $expectedReasonPhrase, string $contentData): void
+    {
+        $contentData = str_replace("\n", "\r\n", $contentData); // Our files uses LF but not CRLF.
+        $response = new HttpResponse([new Stdout($contentData), new EndRequest()]);
+        self::assertSame($expectedStatusCode, $response->getStatusCode(), 'test status code returned');
+        self::assertSame($expectedReasonPhrase, $response->getReasonPhrase(), 'test reason phrase (if included)');
+    }
+
+    public function dataStatusFromFPM(): array
+    {
+        return [
+            [
+                400,
+                'Bad Request',
+                DOCUMENT_ROOT . '/status0.php',
+                'test HTTP status overridden with reason phrase included',
+            ],
+            [
+                401,
+                'Unauthorized',
+                DOCUMENT_ROOT . '/status1.php',
+                'test HTTP status overridden without reason phrase included',
+            ],
+            [
+                402,
+                ' Payment Required',
+                DOCUMENT_ROOT . '/status2.php',
+                'test HTTP status overridden with reason phrase and extra spaces included',
+            ],
+            [
+                403,
+                'Forbidden',
+                DOCUMENT_ROOT . '/status3.php',
+                'test HTTP status overridden with extra spaces included, but no reason phrase',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataStatusFromFPM
+     * @covers \Swoole\FastCGI\HttpResponse
+     * @param mixed $expectedStatusCode
+     * @param mixed $expectedReasonPhrase
+     */
+    public function testStatusFromFPM($expectedStatusCode, $expectedReasonPhrase, string $filename): void
+    {
+        Coroutine\run(
+            function () use ($expectedStatusCode, $expectedReasonPhrase, $filename) {
+                $client = new Client('php-fpm', 9000);
+                $response = $client->execute((new HttpRequest())->withScriptFilename($filename));
+                self::assertSame($expectedStatusCode, $response->getStatusCode(), 'test status code returned');
+                self::assertSame($expectedReasonPhrase, $response->getReasonPhrase(), 'test reason phrase (if included)');
             }
         );
     }

--- a/tests/www/header2.php
+++ b/tests/www/header2.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+header('X-Foo0: Bar0');    // Set a standard HTTP header.
+header('X-Foo1:Bar1');     // Set an HTTP header without space after the colon.
+header('X-Foo2 Bar2');     // Set an invalid HTTP header (without colon included).
+header('X-Foo3:Bar3 ');    // Set an HTTP header with extra space(s) after.
+header(' X-Foo4:Bar4');    // Set an HTTP header with extra space(s) at the beginning.
+header(' X-Foo5:  Bar5 '); // Set an HTTP header with extra space(s) before, after, and in-between.
+
+echo "Hello world!\n";

--- a/tests/www/status0.php
+++ b/tests/www/status0.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+header('HTTP/1.0 200 OK');
+header('Status: 400 Bad Request'); // HTTP status overridden with reason phase included.
+
+echo "Hello world!\n";

--- a/tests/www/status1.php
+++ b/tests/www/status1.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+header('HTTP/1.0 200 OK');
+header('Status: 401'); // HTTP status overridden without reason phase included.
+
+echo "Hello world!\n";

--- a/tests/www/status2.php
+++ b/tests/www/status2.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+header('HTTP/1.0 200 OK');
+header('Status:  402  Payment Required  '); // HTTP status overridden with reason phase and extra spaces included.
+
+echo "Hello world!\n";

--- a/tests/www/status3.php
+++ b/tests/www/status3.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+header('HTTP/1.0 200 OK');
+header('Status:  403  '); // HTTP status overridden with extra spaces included, but no reason phrase.
+
+echo "Hello world!\n";


### PR DESCRIPTION
This is to remove error control operators (the at sign) in class [\Swoole\FastCGI\HttpResponse](https://github.com/swoole/library/blob/master/src/core/FastCGI/HttpResponse.php).