### PR TITLE
remove pgsql driver

### DIFF
--- a/src/core/Database/PDOConfig.php
+++ b/src/core/Database/PDOConfig.php
@@ -15,8 +15,6 @@ class PDOConfig
 {
     public const DRIVER_MYSQL = 'mysql';
 
-    public const DRIVER_PGSQL = 'pgsql';
-
     /** @var string */
     protected $driver = self::DRIVER_MYSQL;
 
@@ -157,7 +155,6 @@ class PDOConfig
     {
         return [
             self::DRIVER_MYSQL,
-            self::DRIVER_PGSQL,
         ];
     }
 }


### PR DESCRIPTION
This option is misleading, because `postgresql` has not been coroutine, need to use [ext-postgresql](https://github.com/swoole/ext-postgresql)