### PR TITLE
fix: set error code and error message when execution fails

### DIFF
--- a/src/core/Curl/Handler.php
+++ b/src/core/Curl/Handler.php
@@ -715,6 +715,8 @@ final class Handler
                 $errCode = $client->errCode;
                 if ($errCode == SWOOLE_ERROR_DNSLOOKUP_RESOLVE_FAILED or $errCode == SWOOLE_ERROR_DNSLOOKUP_RESOLVE_TIMEOUT) {
                     $this->setError(CURLE_COULDNT_RESOLVE_HOST, 'Could not resolve host: ' . $client->host);
+                } else {
+                    $this->setError($errCode, $client->errMsg);
                 }
                 $this->info['total_time'] = microtime(true) - $timeBegin;
                 return false;


### PR DESCRIPTION
Should we add an error code and error message to get the reason for the error? 

For example, in this issue https://github.com/swoole/swoole-src/issues/3480