### PR TITLE
Add ArrayObject::getOr()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
     "scripts": {
         "cs-check": "/usr/bin/env php -d swoole.enable_library=Off ./vendor/bin/php-cs-fixer fix --dry-run",
         "cs-fix": "/usr/bin/env php -d swoole.enable_library=Off ./vendor/bin/php-cs-fixer fix",
+        "test": "/usr/bin/env php -d swoole.enable_library=Off ./vendor/bin/phpunit",
         "post-install-cmd" : [
             "rm -rf ./vendor/swoole/ide-helper/output/swoole_library"
         ],

--- a/src/core/ArrayObject.php
+++ b/src/core/ArrayObject.php
@@ -103,6 +103,19 @@ class ArrayObject implements ArrayAccess, Serializable, Countable, Iterator
     }
 
     /**
+     * @param mixed $key
+     * @param mixed $default
+     * @return ArrayObject|StringObject
+     */
+    public function getOr($key, $default = null)
+    {
+        if (!$this->exists($key)) {
+            return $default;
+        }
+        return static::detectType($this->array[$key]);
+    }
+
+    /**
      * @return mixed
      */
     public function last()

--- a/tests/unit/ArrayObjectTest.php
+++ b/tests/unit/ArrayObjectTest.php
@@ -581,4 +581,10 @@ class ArrayObjectTest extends TestCase
     {
         $this->assertEquals($this->data_4->lastKey(), 'c');
     }
+
+    public function testGetOr()
+    {
+        $this->assertNull($this->data->getOr('undefined_key'));
+        $this->assertSame('default_value', $this->data->getOr('undefined_key', 'default_value'));
+    }
 }


### PR DESCRIPTION
Based on Rust's APIs like `map_or()` and `unwrap_or` this PR provides an alternative way for `get` that returns a default value, instead of throwing an exception, when the key does not exists.