### PR TITLE
Fix CURLOPT_WRITEFUNCTION

### DIFF
--- a/src/core/Curl/Handler.php
+++ b/src/core/Curl/Handler.php
@@ -811,6 +811,10 @@ final class Handler
             }
         }
 
+        if ($this->writeFunction) {
+            call_user_func($this->writeFunction, $client, $transfer);
+            return true;
+        }
         if ($this->returnTransfer) {
             return $this->transfer = $transfer;
         }

--- a/tests/unit/Curl/HandlerTest.php
+++ b/tests/unit/Curl/HandlerTest.php
@@ -107,4 +107,27 @@ class HandlerTest extends TestCase
             curl_close($ch);
         });
     }
+
+    /**
+     * @covers \Swoole\Curl\Handler::execute()
+     */
+    public function testWriteFunction()
+    {
+        Coroutine\run(function () {
+            $url = 'https://httpbin.org/get';
+            $ch = curl_init();
+
+            curl_setopt($ch, CURLOPT_URL, $url);
+            curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $data) {
+                self::assertIsString($data);
+                $body = json_decode($data, true);
+                self::assertSame($body['headers']['Host'], 'httpbin.org');
+                return strlen($data);
+            });
+
+            $res = curl_exec($ch);
+            curl_close($ch);
+            self::assertTrue($res);
+        });
+    }
 }


### PR DESCRIPTION
```php
// composer require guzzlehttp/guzzle

include __DIR__ . '/vendor/autoload.php';

use GuzzleHttp\Client;

Swoole\Runtime::enableCoroutine(SWOOLE_HOOK_ALL);

go(function () {
    $url = 'https://httpbin.org/get';
    $ch = curl_init();

    curl_setopt($ch, CURLOPT_URL, $url);
//    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
    curl_setopt($ch, CURLOPT_WRITEFUNCTION, function ($ch, $data) {
        echo 'Data: ' . $data;
        return strlen($data);
    });

    $data = curl_exec($ch);
    curl_close($ch);
    var_dump($data);
//
//    $client = new Client();
//    $url = 'http://baidu.com';
//    $res = $client->request('GET', $url);
//    var_dump($res->getBody()->getContents());
});
```