### PR TITLE
Handle cURL header names in case insensitive manner

### DIFF
--- a/src/core/Curl/Handler.php
+++ b/src/core/Curl/Handler.php
@@ -317,9 +317,7 @@ final class Handler
         $lowerCaseHeaderName = strtolower($headerName);
 
         if (isset($this->headerMap[$lowerCaseHeaderName])) {
-            $oldHeaderName = $this->headerMap[$lowerCaseHeaderName];
-
-            unset($this->headerMap[$lowerCaseHeaderName], $this->headers[$oldHeaderName]);
+            unset($this->headers[$this->headerMap[$lowerCaseHeaderName]]);
         }
 
         $this->headers[$headerName] = $value;

--- a/src/core/Curl/Handler.php
+++ b/src/core/Curl/Handler.php
@@ -311,7 +311,7 @@ final class Handler
         $this->errCode = $code;
         $this->errMsg = $msg ? $msg : curl_strerror($code);
     }
-    
+
     private function hasHeader(string $headerName): bool
     {
         return isset($this->headerMap[strtolower($headerName)]);
@@ -724,7 +724,7 @@ final class Handler
             // Notice: setHeaders must be placed last, because headers may be changed by other parts
             // As much as possible to ensure that Host is the first header.
             // See: http://tools.ietf.org/html/rfc7230#section-5.4
-            $client->setHeaders($headers);
+            $client->setHeaders($this->headers);
             /**
              * Execute.
              */


### PR DESCRIPTION
As per RFC 2616 Section 4.2 HTTP headers should be case-insensitive. Some of the internal functions, such as `curl_setopt()` modify headers using their canonical name, such as `Content-Type`, `Cookie`, `Referer`, etc. However, using a canonical name might not always work properly, if the client has set a header name in the lower case, such as `content-type`, `referer` or upper case `CONTENT-TYPE`, `COOKIE` or any other mixture of letter casing. In order to fix this problem a new mapping beetwen the lower case header name representation and the actual header name is introduced and is now used when performing any header manipulations.

Fixes swoole/swoole-src#3850