### PR TITLE
fix Coroutine\Barrier mem leak

### DIFF
--- a/src/core/Coroutine/Barrier.php
+++ b/src/core/Coroutine/Barrier.php
@@ -45,9 +45,6 @@ class Barrier
     }
 
     /**
-     * @param Barrier $barrier
-     * @param float|int $timeout
-     *
      * @throws Exception
      */
     public static function wait(Barrier &$barrier, float $timeout = -1)
@@ -57,7 +54,7 @@ class Barrier
         }
         $cid = Coroutine::getCid();
         $barrier->cid = $cid;
-        if ($timeout > 0 && ($timeout_ms = (int)($timeout * 1000)) > 0) {
+        if ($timeout > 0 && ($timeout_ms = (int) ($timeout * 1000)) > 0) {
             $barrier->timer = Timer::after($timeout_ms, function () use ($cid) {
                 self::$cancel_list[$cid] = true;
                 Coroutine::resume($cid);

--- a/src/core/Coroutine/Barrier.php
+++ b/src/core/Coroutine/Barrier.php
@@ -25,17 +25,17 @@ class Barrier
 
     public function __destruct()
     {
-        if ($this->timer != -1) {
+        if ($this->timer !== -1) {
             Timer::clear($this->timer);
-            if (isset(static::$cancel_list[$this->cid])) {
-                unset(static::$cancel_list[$this->cid]);
+            if (isset(self::$cancel_list[$this->cid])) {
+                unset(self::$cancel_list[$this->cid]);
                 return;
             }
         }
-        if ($this->cid != -1 && $this->cid != Coroutine::getCid()) {
+        if ($this->cid !== -1 && $this->cid !== Coroutine::getCid()) {
             Coroutine::resume($this->cid);
         } else {
-            static::$cancel_list[$this->cid] = true;
+            self::$cancel_list[$this->cid] = true;
         }
     }
 
@@ -45,16 +45,19 @@ class Barrier
     }
 
     /**
+     * @param Barrier $barrier
+     * @param float|int $timeout
+     *
      * @throws Exception
      */
     public static function wait(Barrier &$barrier, float $timeout = -1)
     {
-        if ($barrier->cid != -1) {
+        if ($barrier->cid !== -1) {
             throw new Exception('The barrier is waiting, cannot wait again.');
         }
         $cid = Coroutine::getCid();
         $barrier->cid = $cid;
-        if ($timeout > 0 && ($timeout_ms = intval($timeout * 1000)) > 0) {
+        if ($timeout > 0 && ($timeout_ms = (int)($timeout * 1000)) > 0) {
             $barrier->timer = Timer::after($timeout_ms, function () use ($cid) {
                 self::$cancel_list[$cid] = true;
                 Coroutine::resume($cid);
@@ -63,6 +66,8 @@ class Barrier
         $barrier = null;
         if (!isset(self::$cancel_list[$cid])) {
             Coroutine::yield();
+        } else {
+            unset(self::$cancel_list[$cid]);
         }
     }
 }


### PR DESCRIPTION
the static property $cancel_list hold the value set in __destruct in some case.
after barrier object destructed by set it's reference by null, we can unset this that value added in __destruct 

the following test case could trigger this issue

```
    /**
     * Test without execution switching between coroutines.
     *
     * @covers \Swoole\Coroutine\Barrier
     */
    public function testNoCoroutineSwitching()
    {
        run(function () {
            $barrier = Barrier::make();
            $count = 0;
            $N = 4;
            foreach (range(1, $N) as $i) {
                \Swoole\Coroutine::create(function () use ($barrier, &$count) {
                    $count++;
                });
            }
            Barrier::wait($barrier);

            $this->assertSame($N, $count, 'The parent coroutine keeps running without switching execution to child coroutines.');
        });
    }
```