### PR TITLE
Fix substr error

### DIFF
--- a/src/core/StringObject.php
+++ b/src/core/StringObject.php
@@ -119,7 +119,7 @@ class StringObject
     /**
      * @return static
      */
-    public function substr(int $offset, ?int $length = null): self
+    public function substr(int $offset, ?int $length = null)
     {
         return new static(substr($this->string, ...func_get_args()));
     }
@@ -194,7 +194,7 @@ class StringObject
      */
     public function chunkSplit(int $chunkLength = 76, string $chunkEnd = ''): self
     {
-        return new static(chunk_split($this->string, $chunkLength, $chunkEnd));
+        return new static(chunk_split($this->string, ...func_get_args()));
     }
 
     public function chunk(int $splitLength = 1): ArrayObject

--- a/tests/unit/MultibyteStringObjectTest.php
+++ b/tests/unit/MultibyteStringObjectTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class MultibyteStringObjectTest extends TestCase
+{
+    /**
+     * @covers \Swoole\MultibyteStringObject::length()
+     */
+    public function testLength()
+    {
+        $str = 'hello world';
+        $length = swoole_mbstring($str)->length();
+        $this->assertEquals(strlen($str), $length);
+    }
+
+    /**
+     * @covers \Swoole\MultibyteStringObject::indexOf()
+     */
+    public function testIndexOf()
+    {
+        $this->assertEquals(swoole_mbstring('hello swoole and hello world')->indexOf('swoole'), 6);
+    }
+
+    /**
+     * @covers \Swoole\MultibyteStringObject::lastIndexOf()
+     */
+    public function testLastIndexOf()
+    {
+        $this->assertEquals(swoole_mbstring('hello swoole and hello world')->lastIndexOf('hello'), 17);
+    }
+
+    /**
+     * @covers \Swoole\MultibyteStringObject::pos()
+     */
+    public function testPos()
+    {
+        $this->assertEquals(swoole_mbstring('hello swoole and hello world')->pos('and'), 13);
+    }
+
+    /**
+     * @covers \Swoole\MultibyteStringObject::rpos()
+     */
+    public function testRPos()
+    {
+        $this->assertEquals(swoole_mbstring('hello swoole and hello world')->rpos('hello'), 17);
+    }
+
+    /**
+     * @covers \Swoole\MultibyteStringObject::ipos()
+     */
+    public function testIPos()
+    {
+        $this->assertEquals(swoole_mbstring('hello swoole AND hello world')->ipos('and'), 13);
+    }
+
+    /**
+     * @covers \Swoole\MultibyteStringObject::substr()
+     */
+    public function testSubstr()
+    {
+        $this->assertEquals(swoole_mbstring('hello swoole and hello world')
+            ->substr(4, 8)->toString(), 'o swoole');
+    }
+
+    /**
+     * @covers \Swoole\MultibyteStringObject::chunk()
+     */
+    public function chunk()
+    {
+        $r = swoole_mbstring('hello swoole and hello world')->chunk(5)->toArray();
+        $expectResult = [
+            0 => 'hello',
+            1 => ' swoo',
+            2 => 'le an',
+            3 => 'd hel',
+            4 => 'lo wo',
+            5 => 'rld',
+        ];
+        $this->assertEquals($expectResult, $r);
+    }
+}


### PR DESCRIPTION
```
PHP Fatal error:  Declaration of Swoole\MultibyteStringObject::substr(int $offset, ?int $length = NULL, ?string $encoding = NULL) must be compatible with Swoole\StringObject::substr(int $offset, ?int $length = NULL): Swoole\StringObject in @swoole-src/library/core/MultibyteStringObject.php on line 64
```