### PR TITLE
Fix error of get server memory and cpu usage in SWOOLE_BASE mode

### DIFF
--- a/src/core/Server/Admin.php
+++ b/src/core/Server/Admin.php
@@ -986,10 +986,15 @@ class Admin
     {
         $total = 0;
 
-        $result['master'] = self::getProcessMemoryRealUsage($server->master_pid);
+        $result['master'] = $result['manager'] = 0;
+        if (self::haveMasterProcess($server)) {
+            $result['master'] = self::getProcessMemoryRealUsage($server->master_pid);
+        }
         $total += $result['master'];
 
-        $result['manager'] = self::getProcessMemoryRealUsage($server->manager_pid);
+        if (self::haveManagerProcess($server)) {
+            $result['manager'] = self::getProcessMemoryRealUsage($server->manager_pid);
+        }
         $total += $result['manager'];
 
         $n = $server->setting['worker_num'] + $server->setting['task_worker_num'];
@@ -1015,10 +1020,17 @@ class Admin
     {
         $total = 0;
 
-        $result['master'] = self::getProcessCpuUsage($server->master_pid);
+        $result['master'] = $result['manager'] = 0;
+        if (self::haveMasterProcess($server)) {
+            $result['master'] = self::getProcessCpuUsage($server->master_pid);
+        }
+
         $total += $result['master'][1] ?? 0;
 
-        $result['manager'] = self::getProcessCpuUsage($server->manager_pid);
+        if (self::haveManagerProcess($server)) {
+            $result['manager'] = self::getProcessCpuUsage($server->manager_pid);
+        }
+
         $total += $result['manager'][1] ?? 0;
 
         $n = $server->setting['worker_num'] + $server->setting['task_worker_num'];
@@ -1174,12 +1186,7 @@ class Admin
         }
         $process_type = SWOOLE_SERVER_COMMAND_REACTOR_THREAD;
         if (empty($server->setting['reactor_num'])) {
-            if (empty($server->setting['worker_num'])) {
-                $cpu_num = swoole_cpu_num();
-                $reactor_num = $cpu_num >= 8 ? 8 : $cpu_num;
-            } else {
-                $reactor_num = $server->setting['worker_num'];
-            }
+            $reactor_num = $server->setting['worker_num'];
         } else {
             $reactor_num = $server->setting['reactor_num'];
         }
@@ -1192,7 +1199,7 @@ class Admin
     private static function handlerGetAllWorker($cmd, $data, Server $server, bool $json_decode = false)
     {
         $process_type = SWOOLE_SERVER_COMMAND_EVENT_WORKER;
-        $worker_num = empty($server->setting['worker_num']) ? swoole_cpu_num() : $server->setting['worker_num'];
+        $worker_num = $server->setting['worker_num'];
         $list = [];
         for ($process_id = 0; $process_id < $worker_num; $process_id++) {
             $list["worker-{$process_id}"] = $server->command($cmd, $process_id, $process_type, $data, $json_decode);
@@ -1217,7 +1224,7 @@ class Admin
     private static function getProcessCpuUsage($pid)
     {
         // TODO: Support other OS
-        if (PHP_OS_FAMILY !== 'Linux') {
+        if (PHP_OS_FAMILY !== 'Linux' || !file_exists("/proc/{$pid}/stat")) {
             return [0];
         }
 
@@ -1250,10 +1257,10 @@ class Admin
     {
         $array = [];
         // TODO: Support other OS
-        if (PHP_OS_FAMILY !== 'Linux') {
+        if (PHP_OS_FAMILY !== 'Linux' || !file_exists("/proc/{$pid}/status")) {
             return $array;
         }
-        $status = swoole_string(trim(file_get_contents('/proc/' . $pid . '/status')));
+        $status = swoole_string(trim(file_get_contents("/proc/{$pid}/status")));
         $lines = $status->split("\n");
         foreach ($lines as $l) {
             if (empty($l)) {
@@ -1306,6 +1313,24 @@ class Admin
         }
 
         return $size;
+    }
+
+    private static function haveMasterProcess(Server $server): bool
+    {
+        if ($server->mode === SWOOLE_BASE) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static function haveManagerProcess(Server $server): bool
+    {
+        if ($server->mode === SWOOLE_BASE && $server->getManagerPid() === 0) {
+            return false;
+        }
+
+        return true;
     }
 
     private static function json($data, $code = 0)


### PR DESCRIPTION
```
[2021-11-06 20:01:25 *13424.0]  ERROR   php_swoole_server_rshutdown() (ERRNO 503): Fatal error: Uncaught ErrorException: file_get_contents(/proc/0/status): failed to open stream: No such file or directory in @swoole-src/library/core/Server/Admin.php:1186

[2021-11-06 20:00:44 *11265.0]  ERROR   php_swoole_server_rshutdown() (ERRNO 503): Fatal error: Uncaught ErrorException: file_get_contents(/proc/0/stat): failed to open stream: No such file or directory in @swoole-src/library/core/Server/Admin.php:1156
```