### PR TITLE
Refined Docker based development environment

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,12 +21,12 @@ jobs:
           sed -i.bak -e "s/^FROM phpswoole\/swoole.*$/FROM phpswoole\/swoole:php${{ matrix.php }}/g" ./Dockerfile
           docker-compose up -d
           docker ps -a
-          docker exec -t $(docker ps -qf "name=app") bash -c "php -v"
-          docker exec -t $(docker ps -qf "name=app") bash -c "php --ri swoole"
-          docker run --rm -v "$(pwd)":/var/www -t library_app composer install -n
+          docker-compose exec app php -v
+          docker-compose exec app php --ri swoole
+          docker-compose exec app composer install -n
 
       - name: Run Unit Tests
-        run: docker exec -t $(docker ps -qf "name=app") bash -c "./vendor/bin/phpunit"
+        run: docker-compose exec app composer test
 
       - name: Stop and Remove Docker Containers
         run: docker-compose down

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,12 +21,12 @@ jobs:
           sed -i.bak -e "s/^FROM phpswoole\/swoole.*$/FROM phpswoole\/swoole:php${{ matrix.php }}/g" ./Dockerfile
           docker-compose up -d
           docker ps -a
-          docker-compose exec app php -v
-          docker-compose exec app php --ri swoole
-          docker-compose exec app composer install -n
+          docker-compose exec -T app php -v
+          docker-compose exec -T app php --ri swoole
+          docker-compose exec -T app composer install -n
 
       - name: Run Unit Tests
-        run: docker-compose exec app composer test
+        run: docker-compose exec -T app composer test
 
       - name: Stop and Remove Docker Containers
         run: docker-compose down

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Table of Contents
 
 ## How to Contribute
 
-Just new pull request (and we need unit tests for new features)
+Just open new pull requests (and we need unit tests for new features)
 
 ### Code Requirements
 
 + [PSR1](https://www.php-fig.org/psr/psr-1/) and [PSR12](https://www.php-fig.org/psr/psr-12/)
-+ Strict type
++ Strict types
 
 ## Development
 
@@ -37,34 +37,52 @@ Just new pull request (and we need unit tests for new features)
 
 ### Branches
 
-+ **master**: For Swoole 4.6, which supports PHP 7.2+.
-+ **4.5.x**: For Swoole 4.5, which supports PHP 7.1+.
++ **4.6.x**: For Swoole 4.6, which supports PHP 7.2+
++ **4.5.x**: For Swoole 4.5, which supports PHP 7.1+
 
-## Dockerized Local Development
+## Dockerized Local Development (*Compose v2*)
 
-First, run following command to autoload PHP classes/files (no exra Composer packages to be installed):
+First, you need to build the base image:
 
 ```bash
-docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole:latest-dev composer update -n
+docker compose build image
 ```
 
-Secondly, run next command to start Docker containers:
+Then run the following command to autoload PHP classes/files (no extra Composer packages to be installed):
 
 ```bash
-docker-compose up
+docker compose run --rm composer install
+```
+
+Secondly, run the next command to start Docker containers:
+
+```bash
+docker compose up
 ```
 
 Alternatively, if you need to rebuild the service(s) and to restart the containers:
 
 ```bash
-docker-compose build --no-cache
-docker-compose up --force-recreate
+docker compose build image --no-cache
+docker compose up --force-recreate
 ```
 
-Now you can run unit tests included:
+Now you can create an `app`'s `bash` session:
 
 ```bash
-docker exec -t $(docker ps -qf "name=app") ./vendor/bin/phpunit
+docker compose exec app bash
+```
+
+And run commands inside the container:
+
+```bash
+composer test
+```
+
+Or you can tell to run it directly:
+
+```bash
+docker compose exec app composer test
 ```
 
 ## Examples
@@ -75,9 +93,9 @@ examples under folder [examples](https://github.com/swoole/library/tree/master/e
 ### Examples of Database Connection Pool
 
 ```bash
-docker exec -t $(docker ps -qf "name=app") bash -c "php ./examples/mysqli/base.php"
-docker exec -t $(docker ps -qf "name=app") bash -c "php ./examples/pdo/base.php"
-docker exec -t $(docker ps -qf "name=app") bash -c "php ./examples/redis/base.php"
+docker compose exec app php examples/mysqli/base.php
+docker compose exec app php examples/pdo/base.php
+docker compose exec app php examples/redis/base.php
 ```
 
 ### Examples of FastCGI Calls
@@ -89,10 +107,10 @@ found [here](https://github.com/swoole/library/blob/master/examples/fastcgi/prox
 Here are some more examples to make FastCGI calls to PHP-FPM:
 
 ```bash
-docker exec -t $(docker ps -qf "name=app") bash -c "php ./examples/fastcgi/greeter/call.php"
-docker exec -t $(docker ps -qf "name=app") bash -c "php ./examples/fastcgi/greeter/client.php"
-docker exec -t $(docker ps -qf "name=app") bash -c "php ./examples/fastcgi/proxy/base.php"
-docker exec -t $(docker ps -qf "name=app") bash -c "php ./examples/fastcgi/var/client.php"
+docker compose exec app php examples/fastcgi/greeter/call.php
+docker compose exec app php examples/fastcgi/greeter/client.php
+docker compose exec app php examples/fastcgi/proxy/base.php
+docker compose exec app php examples/fastcgi/var/client.php
 ```
 
 ## Compatibility Patch (Swoole version <= v4.4.12)
@@ -106,19 +124,19 @@ define('SWOOLE_USE_SHORTNAME', true); // or false (it depends on you)
 To update Composer packages (optional):
 
 ```bash
-docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole:latest-dev composer update -n
+docker compose run --rm composer update
 ```
 
 To check coding standard violations:
 
 ```bash
-docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole bash -c "composer cs-check"
+docker compose run --rm composer cs-check
 ```
 
 To correct coding standard violations automatically:
 
 ```bash
-docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole bash -c "composer cs-fix"
+docker compose run --rm composer cs-fix
 ```
 
 ## Third Party Libraries
@@ -131,4 +149,4 @@ You can find the licensing information of these third party libraries [here](htt
 
 ## License
 
-This project follows [the Apache 2 license](https://github.com/swoole/library/blob/master/LICENSE).
+This project follows the [Apache 2 license](https://github.com/swoole/library/blob/master/LICENSE).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,24 @@
 version: '3.2'
 
 services:
-  app:
+  image:
+    container_name: swoole-library-image-builder
     build: .
+    image: swoole-library
+    entrypoint: echo
+    command: Image ready
+
+  composer:
+    container_name: swoole-library-composer-runner
+    image: swoole-library
+    entrypoint: composer
+    command: validate
+    volumes:
+      - ./:/var/www
+
+  app:
+    container_name: swoole-library-app
+    image: swoole-library
     links:
       - mysql
       - redis
@@ -17,11 +33,15 @@ services:
     volumes:
       - .:/var/www
       - wordpress:/var/www/html
+
   php-fpm:
+    container_name: swoole-library-php-fpm
     image: php:7.4-fpm
     volumes:
       - .:/var/www
+
   wordpress:
+    container_name: swoole-library-wordpress
     image: wordpress:php7.4-fpm
     links:
       - mysql
@@ -37,27 +57,40 @@ services:
         target: /var/www/html
         volume:
           nocopy: false
+
   mysql:
+    container_name: swoole-library-mysql
     image: mysql:5.7
     environment:
       MYSQL_DATABASE: test
       MYSQL_USER: username
       MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: password
+
   redis:
+    container_name: swoole-library-redis
     image: redis:5.0
+
   nacos:
+    container_name: swoole-library-nacos
     image: nacos/nacos-server
     ports:
       - "8848:8848"
     environment:
       MODE: standalone
       PREFER_HOST_MODE: hostname
+
   consul:
+    container_name: swoole-library-consul
     image: consul
     command:
       consul agent -dev -client=0.0.0.0
     ports:
       - "8500:8500"
+
 volumes:
   wordpress:
+
+networks:
+  default:
+    name: swoole-library-network


### PR DESCRIPTION
It also fixes current documentation that says to run:
```bash
docker run --rm -v "$(pwd)":/var/www -t phpswoole/swoole:latest-dev composer update -n
```
But it actually fails because `phpswoole/swoole:latest-dev` doesn't have `ext-redis` which is required by the `composer.json` manifest file.

---

__This PR should wait #143 and #144 to be green__