### PR TITLE
Removing old PHP versions from CI's style check step

### DIFF
--- a/.github/workflows/syntax_checks.yml
+++ b/.github/workflows/syntax_checks.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ["7.2", "7.3", "7.4", "8.0"]
+        php: ["7.4", "8.0"]
 
     name: Syntax Checks Under PHP ${{ matrix.php }}
 

--- a/.github/workflows/syntax_checks.yml
+++ b/.github/workflows/syntax_checks.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ["7.4", "8.0"]
+        php: ["7.2", "7.3", "7.4", "8.0"]
 
     name: Syntax Checks Under PHP ${{ matrix.php }}
 
@@ -17,4 +17,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run Syntax Checks
-        run: docker run --rm -v "$(pwd):/project" -w /project -i jakzal/phpqa:php${{ matrix.php }} phplint examples src tests
+        run: |
+          if [ ${{ matrix.php }} == '7.3' ] ; then
+            docker run --rm -v "$(pwd):/project" -w /project -i jakzal/phpqa:1.60.0-php7.3        phplint examples src tests
+          else
+            docker run --rm -v "$(pwd):/project" -w /project -i jakzal/phpqa:php${{ matrix.php }} phplint examples src tests
+          fi


### PR DESCRIPTION
`phplint` was removed from `jakzal/phpqa:php7.3` https://github.com/jakzal/toolbox/pull/398

This PR also drops `7.2` support as well.

Fixes CI error:
```
/entrypoint.sh: 6: exec: phplint: not found
Error: Process completed with exit code 127.
```

---

__This PR will neve be green because of #143__