### PR TITLE
Introducing Futures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
             "src/constants.php",
             "src/core/Coroutine/functions.php",
             "src/core/Coroutine/Http/functions.php",
+            "src/core/Future/functions.php",
             "src/std/exec.php",
             "src/ext/curl.php",
             "src/ext/sockets.php",

--- a/examples/futures/docs.php
+++ b/examples/futures/docs.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+use Swoole\Coroutine;
+use Swoole\Coroutine\Http;
+use Swoole\Future;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+\Co\run(static function (): void {
+    $future = Future\async(static function (): void {
+        echo "are lazy\n";
+    });
+
+    Coroutine::create(static function (): void {
+        echo 'Futures ';
+    });
+
+    echo $future->await();
+
+    $future = Future\async(static function (): string {
+        return Http\get('https://httpbin.org/get')->getBody();
+    });
+
+    echo $future->await();
+
+    $future = Future\async(static function (): string {
+        throw new RuntimeException('Futures propagates exceptions');
+    });
+
+    try {
+        $future->await();
+    } catch (Throwable $e) {
+        echo $e->getMessage();
+    }
+});

--- a/examples/futures/functions.php
+++ b/examples/futures/functions.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+
+\Swoole\Coroutine\run(static function () {
+    echo \Swoole\Future\async(static function () {
+        return \Swoole\Coroutine\Http\get('https://httpbin.org/get')->getBody();
+    })->await();
+});

--- a/examples/futures/future.php
+++ b/examples/futures/future.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+
+\Swoole\Coroutine\run(static function () {
+    $future = \Swoole\Future::create(static function () {
+        return \Swoole\Coroutine\Http\get('https://httpbin.org/get')->getBody();
+    });
+
+    echo $future->await();
+});

--- a/examples/futures/join.php
+++ b/examples/futures/join.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+
+\Swoole\Coroutine\run(static function () {
+    $start = microtime(true);
+
+    $future1 = \Swoole\Future::create(static function () {
+        return \Swoole\Coroutine\Http\get('https://httpbin.org/delay/2')->getBody();
+    });
+
+    $future2 = \Swoole\Future::create(static function () {
+        return \Swoole\Coroutine\Http\get('https://httpbin.org/delay/2')->getBody();
+    });
+
+    echo implode(PHP_EOL, \Swoole\Future::join([$future1, $future2]));
+
+    printf("Elapsed %f\n", microtime(true) - $start);
+});

--- a/examples/futures/throw.php
+++ b/examples/futures/throw.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../bootstrap.php';
+
+\Swoole\Coroutine\run(static function () {
+    \Swoole\Future::create(static function () {
+        throw new RuntimeException('Futures exceptions are propagated');
+    })->await();
+});

--- a/src/core/Future.php
+++ b/src/core/Future.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole;
+
+use Swoole\Coroutine\Channel;
+use Throwable;
+
+class Future
+{
+    /**
+     * @var callable
+     */
+    private $func;
+
+    public function __construct(callable $func)
+    {
+        $this->func = $func;
+    }
+
+    public static function create(callable $func): self
+    {
+        return new self($func);
+    }
+
+    public static function join(array $futures, float $timeout = -1): array
+    {
+        $len = count($futures);
+        $ch = new Channel($len);
+        $rets = [];
+
+        Coroutine::join(array_map(static function (Future $future) use ($ch): int {
+            return $future->run($ch);
+        }, $futures));
+
+        while ($len--) {
+            $ret = $ch->pop($timeout);
+
+            if ($ret instanceof Throwable) {
+                throw $ret;
+            }
+
+            $rets[] = $ret;
+        }
+
+        return $rets;
+    }
+
+    public function run(Channel $channel): int
+    {
+        return Coroutine::create(function () use ($channel) {
+            try {
+                $channel->push(($this->func)());
+            } catch (Throwable $throwable) {
+                $channel->push($throwable);
+            }
+        });
+    }
+
+    public function await(float $timeout = -1)
+    {
+        $ch = new Channel(1);
+
+        $cid = $this->run($ch);
+
+        $ret = $ch->pop($timeout);
+
+        if ($ret instanceof Throwable) {
+            throw $ret;
+        }
+
+        return $ret;
+    }
+}

--- a/src/core/Future/functions.php
+++ b/src/core/Future/functions.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Future;
+
+use Swoole\Future;
+
+function async(callable $func): Future
+{
+    return Future::create($func);
+}
+
+function join(...$futures): array
+{
+    return Future::join($futures);
+}

--- a/tests/unit/Future/FutureTest.php
+++ b/tests/unit/Future/FutureTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Future;
+
+use PHPUnit\Framework\TestCase;
+use function Co\run;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class FutureTest extends TestCase
+{
+    public function testAwait(): void
+    {
+        run(function (): void {
+            $future = async(static function (): string {
+                return 'test';
+            });
+
+            $this->assertSame('test', $future->await());
+        });
+    }
+
+    public function testJoin(): void
+    {
+        run(function (): void {
+            $future1 = async(static function (): string {
+                return 'foo';
+            });
+
+            $future2 = async(static function (): string {
+                return 'bar';
+            });
+
+            $strings = join($future1, $future2);
+
+            $this->assertContains('foo', $strings);
+            $this->assertContains('bar', $strings);
+        });
+    }
+}


### PR DESCRIPTION
This PR introduces **Futures** as part of Swoole's standard library features.

**Futures** are abstractions on top of Coroutines providing alternative syntax for building concurrent programs with Swoole.

Main differences from Coroutines are:

### Futures are lazy

They don't evaluate until you call `await`:

```php
$future = Future\async(static function (): void {
    echo "are lazy\n";
});

Coroutine::create(static function (): void {
    echo 'Futures ';
});

echo $future->await();
```

### Futures can return values

The `Channel` handling is done under the hood:

```php
$future = Future\async(static function (): string {
    return Http\get('https://httpbin.org/get')->getBody();
});

echo $future->await();
```

### Futures propagates exceptions

```php
$future = Future\async(static function (): string {
    throw new RuntimeException('Futures propagates exceptions');
});

try {
    $future->await();
} catch (Throwable $e) {
    echo $e->getMessage();
}
```

### Futures synchronization is similar

It uses `Coroutine::join` under the hood:

```php
$future1 = \Swoole\Future::create(static function () {
    return \Swoole\Coroutine\Http\get('https://httpbin.org/delay/2')->getBody();
});

$future2 = \Swoole\Future::create(static function () {
    return \Swoole\Coroutine\Http\get('https://httpbin.org/delay/2')->getBody();
});

echo implode(PHP_EOL, \Swoole\Future::join([$future1, $future2]));
``` 