### PR TITLE
PSR Implementations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require": {
         "php": ">=7.2",
-        "ext-swoole": ">=4.6"
+        "ext-swoole": ">=4.6",
+        "psr/cache": "^1.0"
     },
     "require-dev": {
         "ext-sockets": "*",
@@ -48,7 +49,8 @@
             "src/vendor_init.php"
         ],
         "psr-4": {
-            "Swoole\\": "src/core"
+            "Swoole\\": "src/core",
+            "Swoole\\Psr\\": "src/psr"
         }
     },
     "autoload-dev": {

--- a/src/psr/Cache/PhpSerializer.php
+++ b/src/psr/Cache/PhpSerializer.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Psr\Cache;
+
+class PhpSerializer implements SerializerInterface
+{
+    public function serialize($value): string
+    {
+        return serialize($value);
+    }
+
+    public function unserialize(string $value)
+    {
+        return unserialize($value);
+    }
+}

--- a/src/psr/Cache/SerializerInterface.php
+++ b/src/psr/Cache/SerializerInterface.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Psr\Cache;
+
+interface SerializerInterface
+{
+    public function serialize($value): string;
+
+    public function unserialize(string $value);
+}

--- a/src/psr/Cache/Table/CacheItem.php
+++ b/src/psr/Cache/Table/CacheItem.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Psr\Cache\Table;
+
+use Psr\Cache\CacheItemInterface;
+
+class CacheItem implements CacheItemInterface
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @var int timestamp
+     */
+    private $ttl;
+
+    public function __construct(string $key, $value)
+    {
+        $this->key = $key;
+        $this->value = $value;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function get()
+    {
+        return $this->value;
+    }
+
+    public function isHit(): bool
+    {
+        return true;
+    }
+
+    public function set($value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+
+    public function expiresAt($expiration)
+    {
+        $this->ttl = $expiration->getTimestamp();
+        return $this;
+    }
+
+    public function expiresAfter($time)
+    {
+        $this->ttl = (new \DateTime())->add($time)->getTimestamp();
+        return $this;
+    }
+}

--- a/src/psr/Cache/Table/CacheItemPool.php
+++ b/src/psr/Cache/Table/CacheItemPool.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Psr\Cache\Table;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Swoole\Psr\Cache\SerializerInterface;
+use Swoole\Table;
+
+class CacheItemPool implements CacheItemPoolInterface
+{
+    /**
+     * @var int
+     */
+    private $size;
+
+    /**
+     * @var SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var array
+     */
+    private $deferred;
+
+    /**
+     * @var Table
+     */
+    private $table;
+
+    public function __construct(int $size, SerializerInterface $serializer)
+    {
+        $this->size = $size;
+        $this->serializer = $serializer;
+
+        $this->deferred = [];
+        $this->table = $this->createTable();
+    }
+
+    /**
+     * @param string $key
+     */
+    public function getItem($key): CacheItemInterface
+    {
+        $row = $this->table->get($key);
+        return $this->cacheItemFromRow($row);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        foreach ($keys as $key) {
+            yield $this->getItem($key);
+        }
+    }
+
+    /**
+     * @param string $key
+     */
+    public function hasItem($key): bool
+    {
+        return $this->table->exists($key);
+    }
+
+    public function clear(): bool
+    {
+        $destroyed = $this->table->destroy();
+        $this->table = $this->createTable();
+        return $destroyed;
+    }
+
+    /**
+     * @param string $key
+     */
+    public function deleteItem($key): bool
+    {
+        return $this->table->delete($key);
+    }
+
+    /**
+     * @param array<string> $keys
+     */
+    public function deleteItems(array $keys): bool
+    {
+        foreach ($keys as $key) {
+            if (!$this->deleteItem($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        return $this->table->set($item->getKey(), $this->rowFromCacheItem($item));
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        $this->deferred[] = $item;
+        return true;
+    }
+
+    public function commit(): bool
+    {
+        foreach ($this->deferred as $item) {
+            if (!$this->save($item)) {
+                return false;
+            }
+        }
+
+        $this->deferred = [];
+        return true;
+    }
+
+    private function createTable(): Table
+    {
+        $table = new Table($this->size);
+        $table->column('key', Table::TYPE_STRING, 64);
+        $table->column('value', Table::TYPE_STRING, 64);
+        $table->column('ttl', Table::TYPE_INT);
+        $table->create();
+
+        return $table;
+    }
+
+    private function cacheItemFromRow(array $row): CacheItemInterface
+    {
+        return new CacheItem($row['key'], $this->serializer->unserialize($row['value']));
+    }
+
+    private function rowFromCacheItem(CacheItemInterface $item): array
+    {
+        return [
+            'key' => $item->getKey(),
+            'value' => $this->serializer->serialize($item->get()),
+        ];
+    }
+}

--- a/tests/unit/Psr/Cache/Table/CacheItemPoolTest.php
+++ b/tests/unit/Psr/Cache/Table/CacheItemPoolTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of Swoole.
+ *
+ * @link     https://www.swoole.com
+ * @contact  team@swoole.com
+ * @license  https://github.com/swoole/library/blob/master/LICENSE
+ */
+
+declare(strict_types=1);
+
+namespace Swoole\Psr\Cache\Table;
+
+use PHPUnit\Framework\TestCase;
+use Swoole\Psr\Cache\PhpSerializer;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class CacheItemPoolTest extends TestCase
+{
+    /**
+     * @var CacheItemPool
+     */
+    private $pool;
+
+    protected function setUp(): void
+    {
+        $this->pool = new CacheItemPool(1024, new PhpSerializer());
+    }
+
+    public function testClear()
+    {
+        $this->pool->save(new CacheItem('foo', 'bar'));
+        $this->assertTrue($this->pool->hasItem('foo'));
+        $this->pool->clear();
+        $this->assertFalse($this->pool->hasItem('foo'));
+    }
+
+    public function testDeleteItem()
+    {
+        $this->pool->save(new CacheItem('foo', 'bar'));
+        $this->assertTrue($this->pool->hasItem('foo'));
+        $this->pool->deleteItem('foo');
+        $this->assertFalse($this->pool->hasItem('foo'));
+    }
+
+    public function testSaveDeferredAndCommit()
+    {
+        $this->pool->saveDeferred(new CacheItem('foo', 'bar'));
+        $this->assertFalse($this->pool->hasItem('foo'));
+        $this->pool->commit();
+        $this->assertTrue($this->pool->hasItem('foo'));
+    }
+
+    public function testDeleteItems()
+    {
+        $this->pool->save(new CacheItem('foo', 'bar'));
+        $this->assertTrue($this->pool->hasItem('foo'));
+        $this->pool->deleteItems(['foo']);
+        $this->assertFalse($this->pool->hasItem('foo'));
+    }
+
+    public function testGetItems()
+    {
+        $this->pool->save(new CacheItem('foo', 'bar'));
+        $item = $this->pool->getItem('foo');
+        $this->assertSame('foo', $item->getKey());
+        $this->assertSame('bar', $item->get());
+    }
+
+    public function testGetItem()
+    {
+        $this->pool->save(new CacheItem('foo', 'bar'));
+
+        foreach ($this->pool->getItems(['foo']) as $item) {
+            $this->assertSame('foo', $item->getKey());
+            $this->assertSame('bar', $item->get());
+        }
+    }
+}


### PR DESCRIPTION
This PR proposes a `psr/` directory at Library's source-code (`src/`) to receive [PSR](https://www.php-fig.org/psr/) implementations based on Swoole's ecosystem.

As a reference the [“PSR-6: Caching Interface”](https://www.php-fig.org/psr/psr-6/) was implemented using `Swoole\Table` underneath.

PSRs are becoming more and more a vital part of the PHP developer's daily work and Swoole can't be outside this community's effort to make this integrate seeamsly.

After this idea being approved, planned implementations includes:

- PSR-7 | HTTP Message Interface
- PSR-15 | HTTP Handlers
- PSR-17 | HTTP Factories
- PSR-18 | HTTP Client