### PR TITLE
Do not use option 'charset', if driver is 'pgsql'

### DIFF
--- a/src/core/Database/PDOPool.php
+++ b/src/core/Database/PDOPool.php
@@ -30,15 +30,19 @@ class PDOPool extends ConnectionPool
     {
         $this->config = $config;
         parent::__construct(function () {
+            $driver = $this->config->getDriver();
             return new PDO(
-                "{$this->config->getDriver()}:" .
+                "{$driver}:" .
                 (
                     $this->config->hasUnixSocket() ?
                     "unix_socket={$this->config->getUnixSocket()};" :
                     "host={$this->config->getHost()};" . "port={$this->config->getPort()};"
                 ) .
                 "dbname={$this->config->getDbname()};" .
-                "charset={$this->config->getCharset()}",
+                (
+                    ($driver !== 'pgsql') ? 
+                    "charset={$this->config->getCharset()}" : ""
+                ),
                 $this->config->getUsername(),
                 $this->config->getPassword(),
                 $this->config->getOptions()


### PR DESCRIPTION
If driver is 'pgsql', then 'charset' option must not be used else it gives fatal error.

Note: Database character set can be configured using "options" option.