### PR TITLE
Support array authentication in RedisConfig for ACL

### DIFF
--- a/src/core/Database/RedisConfig.php
+++ b/src/core/Database/RedisConfig.php
@@ -25,7 +25,8 @@ class RedisConfig
 
     protected float $read_timeout = 0.0;
 
-    protected string $auth = '';
+    /** @var string|string[] */
+    protected string|array $auth = '';
 
     protected int $dbIndex = 0;
 
@@ -100,12 +101,18 @@ class RedisConfig
         return $this;
     }
 
-    public function getAuth(): string
+    /**
+     * @return string|string[]
+     */
+    public function getAuth(): string|array
     {
         return $this->auth;
     }
 
-    public function withAuth(string $auth): self
+    /**
+     * @param string|string[] $auth string for password only, array for [username, password]
+     */
+    public function withAuth(string|array $auth): self
     {
         $this->auth = $auth;
         return $this;


### PR DESCRIPTION
feat: support array auth in RedisConfig for Redis ACL (username + password)
so it behaves just like PhpRedis (https://phpredis.github.io/phpredis/Redis.html#method_auth)