### PR TITLE
Fix null key deprecation in ArrayObject::valid() on PHP 8.5

### DIFF
--- a/src/core/ArrayObject.php
+++ b/src/core/ArrayObject.php
@@ -83,7 +83,7 @@ class ArrayObject implements \ArrayAccess, \Serializable, \Countable, \Iterator
 
     public function valid(): bool
     {
-        return array_key_exists($this->key(), $this->array);
+        return $this->key() !== null;
     }
 
     /**

--- a/tests/unit/ArrayObjectTest.php
+++ b/tests/unit/ArrayObjectTest.php
@@ -98,6 +98,29 @@ class ArrayObjectTest extends TestCase
         $this->assertEquals($this->control_data, $newArray);
     }
 
+    public function testValidAtEndOfArray(): void
+    {
+        $data = swoole_array([1, 2, 3]);
+
+        $errorRaised = false;
+        set_error_handler(static function () use (&$errorRaised): bool {
+            $errorRaised = true;
+            return true;
+        });
+
+        $values = [];
+        foreach ($data as $value) {
+            $values[] = $value;
+        }
+        $validAtEnd = $data->valid();
+
+        restore_error_handler();
+
+        $this->assertSame([1, 2, 3], $values);
+        $this->assertFalse($validAtEnd);
+        $this->assertFalse($errorRaised);
+    }
+
     public function testRemove(): void
     {
         $data1 = swoole_array_list('hello', 'world', 'swoole');


### PR DESCRIPTION
On PHP 8.5, iterating a `Swoole\ArrayObject` to the end triggers a deprecation notice because `key()` returns null once the internal pointer moves past the last element and `valid()` passes that straight into `array_key_exists()`. Using the standard `key() !== null` check avoids it.

Fixes swoole/swoole-src#6089
