### PR TITLE
Support CURLOPT_PREREQFUNCTION in coroutine curl handler

### DIFF
--- a/src/core/Curl/Handler.php
+++ b/src/core/Curl/Handler.php
@@ -110,6 +110,9 @@ final class Handler implements \Stringable
     /** @var callable */
     private $progressFunction;
 
+    /** @var callable|null */
+    private $prereqFunction;
+
     private $returnTransfer = false;
 
     private $method = '';
@@ -678,6 +681,10 @@ final class Handler implements \Stringable
                 $this->method = 'GET';
                 break;
             default:
+                if (defined('CURLOPT_PREREQFUNCTION') && $opt === CURLOPT_PREREQFUNCTION) {
+                    $this->prereqFunction = $value;
+                    break;
+                }
                 throw new CurlException("swoole_curl_setopt(): option[{$opt}] is not supported");
         }
         return true;

--- a/tests/unit/Curl/HandlerTest.php
+++ b/tests/unit/Curl/HandlerTest.php
@@ -70,6 +70,22 @@ class HandlerTest extends TestCase
         });
     }
 
+    public function testPrereqFunction(): void
+    {
+        if (!defined('CURLOPT_PREREQFUNCTION')) {
+            self::markTestSkipped('CURLOPT_PREREQFUNCTION requires PHP >= 8.2 and libcurl >= 7.80.0');
+        }
+        Coroutine\run(function () {
+            $ch = curl_init('http://httpbin.org/get');
+            self::assertInstanceOf(Handler::class, $ch);
+            self::assertTrue(curl_setopt($ch, CURLOPT_PREREQFUNCTION, function () {
+                return CURL_PREREQFUNC_OK;
+            }));
+            // Guzzle clears it with null on handle release
+            self::assertTrue(curl_setopt($ch, CURLOPT_PREREQFUNCTION, null));
+        });
+    }
+
     public function testCustomHost(): void
     {
         Coroutine\run(function () {


### PR DESCRIPTION
Guzzle 7.13 registers `CURLOPT_PREREQFUNCTION` and sets it back to `null` when it releases each handle. Under `SWOOLE_HOOK_CURL` that call lands in `Handler::setOption()`, which doesn't know the option and throws `swoole_curl_setopt(): option[20312] is not supported`, so every request made through Guzzle blows up. This accepts the option the same way the other callback options are handled. The constant only exists on PHP 8.2+ with libcurl 7.80 or newer, so it's guarded with `defined()` to avoid breaking older builds.

Fixes swoole/swoole-src#6098
